### PR TITLE
Set up GitHub Actions for Automatic PyPI Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Python environment
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      # Install dependencies for building and publishing
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      # Extract version from setup.py
+      - name: Extract version from setup.py
+        id: extract_version
+        run: |
+          version=$(python -c "exec(open('setup.py').read()); print(__version__)")
+          echo "VERSION=$version" >> $GITHUB_ENV
+
+      # Log the extracted version
+      - name: Show extracted version
+        run: echo "Extracted Version: ${{ env.VERSION }}"
+
+      # Build the package
+      - name: Build the package
+        run: python -m build
+
+      # Publish to PyPI
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import setup, find_packages
 
+__version__ = '5.0.3'
+
 setup(
     name='abarorm',
-    version='5.0.2',
+    version=__version__,
     description='abarorm is a lightweight and easy-to-use Object-Relational Mapping (ORM) library for SQLite and PostgreSQL databases in Python. It aims to provide a simple and intuitive interface for managing database models and interactions.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION

## Overview
This PR configures GitHub Actions to automatically publish the **abarorm** package to PyPI whenever changes are pushed to the `main` branch. With this setup, the version will be extracted from the `setup.py` file and the package will be built and uploaded to PyPI.

## Changes Made:
- Added a new GitHub Actions workflow file (`.github/workflows/publish.yml`).
- The workflow automatically triggers when a push is made to the `main` branch.
- The version number is extracted from the `setup.py` file.
- The package is built using `python -m build` and uploaded to PyPI using `twine`.

## How It Works:
- When a change is pushed to the `main` branch, GitHub Actions will:
  - Check out the code.
  - Set up the Python environment.
  - Install necessary build tools (`build`, `twine`).
  - Extract the version number from `setup.py`.
  - Build the package and publish it to PyPI.